### PR TITLE
Revert "Bump slate from 0.47.9 to 0.50.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1670,11 +1670,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
     },
-    "@types/esrever": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/esrever/-/esrever-0.2.0.tgz",
-      "integrity": "sha512-5NI6TeGzVEy/iBcuYtcPzzIC6EqlfQ2+UZ54vT0ulq8bPNGAy8UJD+XcsAyEOcnYFUjOVWuUV+k4/rVkxt9/XQ=="
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -4459,6 +4454,11 @@
         "arrify": "^1.0.1",
         "path-type": "^3.0.0"
       }
+    },
+    "direction": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
+      "integrity": "sha1-zl15f5fib4vnvv9T99xA4cGp7Ew="
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -13524,33 +13524,24 @@
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
     },
     "slate": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.50.0.tgz",
-      "integrity": "sha512-qPQASNUGQ8v50ejaiiQB8Y4LQMyhMSaqeoXv69jyOLj2LaUMQXZxhPo0tHtxRBdXYhqddR7TuVo8lKkaIDI50A==",
+      "version": "0.47.9",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.47.9.tgz",
+      "integrity": "sha512-EK4O6b7lGt+g5H9PGw9O5KCM4RrOvOgE9mPi3rzQ0zDRlgAb2ga4TdpS6XNQbrsJWsc8I1fjaSsUeCqCUhhi9A==",
       "requires": {
-        "@types/esrever": "^0.2.0",
+        "debug": "^3.1.0",
+        "direction": "^0.1.5",
         "esrever": "^0.2.0",
-        "immer": "^5.0.0",
-        "is-plain-object": "^3.0.0"
+        "is-plain-object": "^2.0.4",
+        "lodash": "^4.17.4",
+        "tiny-invariant": "^1.0.1",
+        "tiny-warning": "^0.0.3",
+        "type-of": "^2.0.1"
       },
       "dependencies": {
-        "immer": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/immer/-/immer-5.0.0.tgz",
-          "integrity": "sha512-G7gRqKbi9NE025XVyqyTV98dxUOtdKvu/P1QRaVZfA55aEcXgjbxPdm+TlWdcSMNPKijlaHNz61DGPyelouRlA=="
-        },
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        "tiny-warning": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-0.0.3.tgz",
+          "integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
         }
       }
     },
@@ -14626,6 +14617,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "type-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz",
+      "integrity": "sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-scripts": "3.2.0",
     "react-table": "^7.0.0-beta.15",
     "react-tabs": "^3.0.0",
-    "slate": "^0.50.0",
+    "slate": "^0.47.9",
     "slate-drop-or-paste-images": "^0.9.1",
     "slate-react": "^0.22.10",
     "use-debounce": "^3.1.0"


### PR DESCRIPTION
Reverts quiz-us/teacher-client#67

Looks like `0.50.0` is actually a major update that requires significant migration (https://docs.slatejs.org/concepts/xx-migrating). Will revert for now and then dedicate some time to properly migrate this.